### PR TITLE
BNC-2151 - Use environment files to set Github Output instead of deprecated ::set-output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ terraform.rc
 
 # Ignore binary
 tfci
+
+# Repomix output ignore
+repomix-output.txt

--- a/.repomixignore
+++ b/.repomixignore
@@ -1,0 +1,3 @@
+*.log
+tfci
+**.env**

--- a/repomix.config.json
+++ b/repomix.config.json
@@ -1,0 +1,27 @@
+{
+  "output": {
+    "filePath": "repomix-output.txt",
+    "style": "plain",
+    "parsableStyle": false,
+    "fileSummary": true,
+    "directoryStructure": true,
+    "removeComments": false,
+    "removeEmptyLines": false,
+    "compress": false,
+    "topFilesLength": 5,
+    "showLineNumbers": false,
+    "copyToClipboard": false
+  },
+  "include": [],
+  "ignore": {
+    "useGitignore": true,
+    "useDefaultPatterns": true,
+    "customPatterns": []
+  },
+  "security": {
+    "enableSecurityCheck": true
+  },
+  "tokenCount": {
+    "encoding": "o200k_base"
+  }
+}


### PR DESCRIPTION
# Summary
Use Github environment files to set outputs instead of the deprecated ::set-output

## 📝 Details
The package currently uses the old ::set-output to populate the env vars. It has been deprecated since 2023, although it's unclear when they pulled the plug on them.
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Currently, the plans don't really work as the configuration_id generated by the `upload` command is never used. Since it is not set in the outputs, it defaults to the configuration id of the latest apply, which just does a plan on what is currently deployed, essentially not detecting any changes

## 💣 Breaking Changes
This replaces using ::set-output

## 🧪 How did you test it?
Unit tests
